### PR TITLE
Add Flask server and API test page

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,5 @@ matplotlib>=3.5.0
 numpy>=1.21.0
 Pillow>=9.0.0
 scikit-learn>=1.3.0
+Flask>=2.3.0
+flask-cors>=4.0.0

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,230 @@
+"""Simple Flask server exposing OpinionSystem operations as REST endpoints."""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, Tuple
+
+import yaml
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "backend" / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+CONFIG_PATH = PROJECT_ROOT / "config.yaml"
+
+
+def _load_config() -> Dict[str, Any]:
+    if CONFIG_PATH.is_file():
+        with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    LOGGER.warning("Configuration file %s not found, using defaults", CONFIG_PATH)
+    return {}
+
+
+def _serialise_result(value: Any) -> Any:
+    """Make sure the result can be JSON serialised."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_serialise_result(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _serialise_result(val) for key, val in value.items()}
+
+    # Handle common dataframe-like objects lazily to avoid hard dependency.
+    try:
+        import pandas as pd  # type: ignore
+
+        if isinstance(value, pd.DataFrame):
+            return value.to_dict(orient="records")
+        if isinstance(value, pd.Series):
+            return value.to_dict()
+    except Exception:  # pragma: no cover - optional dependency
+        pass
+
+    try:
+        return json.loads(json.dumps(value, default=str))
+    except TypeError:
+        return str(value)
+
+
+def _execute_operation(operation: str, caller: Callable[..., Any], *args: Any, **kwargs: Any) -> Tuple[Dict[str, Any], int]:
+    try:
+        result = caller(*args, **kwargs)
+        return {
+            "status": "ok",
+            "operation": operation,
+            "data": _serialise_result(result),
+        }, 200
+    except Exception as exc:  # pragma: no cover - defensive: surface backend errors
+        LOGGER.exception("Error while executing operation %s", operation)
+        return {
+            "status": "error",
+            "operation": operation,
+            "message": str(exc),
+        }, 500
+
+
+def _require_fields(payload: Dict[str, Any], *fields: str) -> Tuple[bool, Dict[str, Any]]:
+    missing = [field for field in fields if not payload.get(field)]
+    if missing:
+        return False, {
+            "status": "error",
+            "message": f"Missing required field(s): {', '.join(missing)}",
+        }
+    return True, {}
+
+
+app = Flask(__name__)
+CORS(app)
+
+CONFIG = _load_config()
+
+
+@app.get("/api/status")
+def status():
+    return jsonify({
+        "status": "ok",
+        "message": "OpinionSystem backend is running",
+        "config": {
+            "backend": CONFIG.get("backend", {}),
+        },
+    })
+
+
+@app.get("/api/config")
+def get_config():
+    return jsonify(CONFIG)
+
+
+@app.post("/api/merge")
+def merge_endpoint():
+    payload = request.get_json(silent=True) or {}
+    valid, error = _require_fields(payload, "topic", "date")
+    if not valid:
+        return jsonify(error), 400
+
+    from src.merge import run_merge  # type: ignore
+
+    response, code = _execute_operation("merge", run_merge, payload["topic"], payload["date"])
+    return jsonify(response), code
+
+
+@app.post("/api/clean")
+def clean_endpoint():
+    payload = request.get_json(silent=True) or {}
+    valid, error = _require_fields(payload, "topic", "date")
+    if not valid:
+        return jsonify(error), 400
+
+    from src.clean import run_clean  # type: ignore
+
+    response, code = _execute_operation("clean", run_clean, payload["topic"], payload["date"])
+    return jsonify(response), code
+
+
+@app.post("/api/filter")
+def filter_endpoint():
+    payload = request.get_json(silent=True) or {}
+    valid, error = _require_fields(payload, "topic", "date")
+    if not valid:
+        return jsonify(error), 400
+
+    from src.filter import run_filter  # type: ignore
+
+    response, code = _execute_operation("filter", run_filter, payload["topic"], payload["date"])
+    return jsonify(response), code
+
+
+@app.post("/api/upload")
+def upload_endpoint():
+    payload = request.get_json(silent=True) or {}
+    valid, error = _require_fields(payload, "topic", "date")
+    if not valid:
+        return jsonify(error), 400
+
+    from src.update import run_update  # type: ignore
+
+    response, code = _execute_operation("upload", run_update, payload["topic"], payload["date"])
+    return jsonify(response), code
+
+
+@app.post("/api/query")
+def query_endpoint():
+    from src.query import run_query  # type: ignore
+
+    response, code = _execute_operation("query", run_query)
+    return jsonify(response), code
+
+
+@app.post("/api/fetch")
+def fetch_endpoint():
+    payload = request.get_json(silent=True) or {}
+    valid, error = _require_fields(payload, "topic", "start", "end")
+    if not valid:
+        return jsonify(error), 400
+
+    from src.fetch import run_fetch  # type: ignore
+
+    response, code = _execute_operation(
+        "fetch", run_fetch, payload["topic"], payload["start"], payload["end"]
+    )
+    return jsonify(response), code
+
+
+@app.post("/api/analyze")
+def analyze_endpoint():
+    payload = request.get_json(silent=True) or {}
+    valid, error = _require_fields(payload, "topic", "start", "end")
+    if not valid:
+        return jsonify(error), 400
+
+    func = payload.get("function")
+
+    from src.analyze import run_Analyze  # type: ignore
+
+    response, code = _execute_operation(
+        "analyze",
+        run_Analyze,
+        payload["topic"],
+        payload["start"],
+        end_date=payload["end"],
+        only_function=func,
+    )
+    return jsonify(response), code
+
+
+@app.route("/")
+def root():
+    return jsonify({"message": "OpinionSystem API", "endpoints": [
+        "/api/status",
+        "/api/config",
+        "/api/merge",
+        "/api/clean",
+        "/api/filter",
+        "/api/upload",
+        "/api/query",
+        "/api/fetch",
+        "/api/analyze",
+    ]})
+
+
+def main() -> None:
+    backend_cfg = CONFIG.get("backend", {})
+    host = backend_cfg.get("host", "127.0.0.1")
+    port = int(backend_cfg.get("port", 8000))
+    LOGGER.info("Starting OpinionSystem backend on %s:%s", host, port)
+    app.run(host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+frontend:
+  host: 127.0.0.1
+  port: 5173
+  base_url: http://127.0.0.1:5173
+backend:
+  host: 127.0.0.1
+  port: 8000
+  base_url: http://127.0.0.1:8000

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,10 +3,293 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Opinion System Frontend</title>
+    <title>Opinion System API 测试台</title>
+    <style>
+      :root {
+        font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+        background: #f4f6fb;
+        color: #1f2933;
+      }
+
+      body {
+        margin: 0;
+        padding: 2rem;
+        line-height: 1.6;
+      }
+
+      h1 {
+        margin-bottom: 1rem;
+      }
+
+      section {
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+      }
+
+      form {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      label {
+        font-weight: 600;
+      }
+
+      input,
+      button,
+      select {
+        padding: 0.6rem 0.75rem;
+        font-size: 1rem;
+        border-radius: 8px;
+        border: 1px solid #d3dce6;
+      }
+
+      button {
+        background: #2563eb;
+        color: #ffffff;
+        border: none;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      button:hover {
+        background: #1d4ed8;
+      }
+
+      pre {
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 1rem;
+        border-radius: 8px;
+        overflow-x: auto;
+      }
+
+      .two-column {
+        display: grid;
+        gap: 1rem;
+      }
+
+      @media (min-width: 900px) {
+        .two-column {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <h1>Opinion System API 测试台</h1>
+    <p>
+      此页面用于验证前后端通信。请先启动 <code>backend/server.py</code> 对应的 Flask 服务，确保配置中的端口号一致。
+    </p>
+
+    <section>
+      <h2>服务状态</h2>
+      <button id="statusBtn">检查后端状态</button>
+      <pre id="statusResult">等待调用...</pre>
+    </section>
+
+    <section class="two-column">
+      <div>
+        <h2>数据合并 / 清洗 / 筛选 / 上传</h2>
+        <form id="pipelineForm">
+          <label>
+            专题 Topic
+            <input type="text" name="topic" placeholder="例如：示例专题" required />
+          </label>
+          <label>
+            日期 Date (YYYY-MM-DD)
+            <input type="text" name="date" placeholder="2024-01-01" required />
+          </label>
+          <label>
+            操作 Operation
+            <select name="operation" required>
+              <option value="merge">Merge</option>
+              <option value="clean">Clean</option>
+              <option value="filter">Filter</option>
+              <option value="upload">Upload</option>
+            </select>
+          </label>
+          <button type="submit">执行操作</button>
+        </form>
+        <pre id="pipelineResult">等待调用...</pre>
+      </div>
+
+      <div>
+        <h2>数据库操作</h2>
+        <button id="queryBtn">查询 Query</button>
+        <pre id="queryResult">等待调用...</pre>
+      </div>
+    </section>
+
+    <section class="two-column">
+      <div>
+        <h2>数据提取 Fetch</h2>
+        <form id="fetchForm">
+          <label>
+            专题 Topic
+            <input type="text" name="topic" placeholder="例如：示例专题" required />
+          </label>
+          <label>
+            开始日期 Start (YYYY-MM-DD)
+            <input type="text" name="start" placeholder="2024-01-01" required />
+          </label>
+          <label>
+            结束日期 End (YYYY-MM-DD)
+            <input type="text" name="end" placeholder="2024-01-07" required />
+          </label>
+          <button type="submit">提取数据</button>
+        </form>
+        <pre id="fetchResult">等待调用...</pre>
+      </div>
+
+      <div>
+        <h2>数据分析 Analyze</h2>
+        <form id="analyzeForm">
+          <label>
+            专题 Topic
+            <input type="text" name="topic" placeholder="例如：示例专题" required />
+          </label>
+          <label>
+            开始日期 Start (YYYY-MM-DD)
+            <input type="text" name="start" placeholder="2024-01-01" required />
+          </label>
+          <label>
+            结束日期 End (YYYY-MM-DD)
+            <input type="text" name="end" placeholder="2024-01-07" required />
+          </label>
+          <label>
+            (可选) 指定函数 Function
+            <input type="text" name="function" placeholder="函数名称" />
+          </label>
+          <button type="submit">运行分析</button>
+        </form>
+        <pre id="analyzeResult">等待调用...</pre>
+      </div>
+    </section>
+
+    <script>
+      const state = {
+        backendBase: "http://127.0.0.1:8000",
+        configLoaded: false,
+      };
+
+      const prettyPrint = (elementId, data) => {
+        document.getElementById(elementId).textContent = JSON.stringify(data, null, 2);
+      };
+
+      const handleError = (elementId, error) => {
+        prettyPrint(elementId, {
+          status: "error",
+          message: error.message || error,
+        });
+      };
+
+      async function ensureConfig() {
+        if (state.configLoaded) {
+          return;
+        }
+        try {
+          const response = await fetch(`${state.backendBase}/api/config`);
+          if (!response.ok) throw new Error(`配置获取失败: ${response.status}`);
+          const config = await response.json();
+          if (config.backend && config.backend.base_url) {
+            state.backendBase = config.backend.base_url;
+          } else if (config.backend && config.backend.host && config.backend.port) {
+            state.backendBase = `http://${config.backend.host}:${config.backend.port}`;
+          }
+          state.configLoaded = true;
+        } catch (error) {
+          console.warn("加载配置失败，使用默认后端地址", error);
+          state.configLoaded = true;
+        }
+      }
+
+      async function callApi(path, options = {}) {
+        await ensureConfig();
+        const response = await fetch(`${state.backendBase}${path}`, {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          ...options,
+        });
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || `请求失败: ${response.status}`);
+        }
+        return response.json();
+      }
+
+      document.getElementById("statusBtn").addEventListener("click", async () => {
+        try {
+          const data = await callApi("/api/status", { method: "GET" });
+          prettyPrint("statusResult", data);
+        } catch (error) {
+          handleError("statusResult", error);
+        }
+      });
+
+      document.getElementById("queryBtn").addEventListener("click", async () => {
+        try {
+          const data = await callApi("/api/query", { method: "POST", body: JSON.stringify({}) });
+          prettyPrint("queryResult", data);
+        } catch (error) {
+          handleError("queryResult", error);
+        }
+      });
+
+      document.getElementById("pipelineForm").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = Object.fromEntries(formData.entries());
+        try {
+          const data = await callApi(`/api/${payload.operation}`, {
+            method: "POST",
+            body: JSON.stringify({ topic: payload.topic, date: payload.date }),
+          });
+          prettyPrint("pipelineResult", data);
+        } catch (error) {
+          handleError("pipelineResult", error);
+        }
+      });
+
+      document.getElementById("fetchForm").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = Object.fromEntries(formData.entries());
+        try {
+          const data = await callApi("/api/fetch", {
+            method: "POST",
+            body: JSON.stringify(payload),
+          });
+          prettyPrint("fetchResult", data);
+        } catch (error) {
+          handleError("fetchResult", error);
+        }
+      });
+
+      document.getElementById("analyzeForm").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = Object.fromEntries(formData.entries());
+        if (!payload.function) {
+          delete payload.function;
+        }
+        try {
+          const data = await callApi("/api/analyze", {
+            method: "POST",
+            body: JSON.stringify(payload),
+          });
+          prettyPrint("analyzeResult", data);
+        } catch (error) {
+          handleError("analyzeResult", error);
+        }
+      });
+
+      // 自动触发一次状态检查
+      document.getElementById("statusBtn").click();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Flask-based REST API server that bridges the existing opinion processing modules
- introduce a shared YAML config to capture local frontend/backend endpoints
- provide a static HTML harness to exercise key API endpoints from the browser and enable CORS

## Testing
- python -m compileall backend/server.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cb6a22d083279dffcfa0dd65f8e5