### PR TITLE
Fix sidebar behavior and improve dataset upload guidance

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,21 @@
 <template>
-  <div class="app-shell">
-    <aside class="app-shell__sidebar">
+  <div class="app-shell" :class="{ 'app-shell--collapsed': sidebarCollapsed }">
+    <aside
+      class="app-shell__sidebar"
+      :class="{ 'app-shell__sidebar--collapsed': sidebarCollapsed }"
+    >
+      <button
+        type="button"
+        class="app-shell__collapse-toggle"
+        :aria-expanded="!sidebarCollapsed"
+        :aria-label="sidebarToggleLabel"
+        @click="toggleSidebar"
+      >
+        <component
+          :is="sidebarCollapsed ? ChevronDoubleRightIcon : ChevronDoubleLeftIcon"
+          class="app-shell__collapse-icon"
+        />
+      </button>
       <RouterLink to="/" class="app-shell__brand">
         <span class="app-shell__logo">Opinion System</span>
         <span class="app-shell__tagline">项目制舆情工作台</span>
@@ -33,9 +48,15 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { RouterLink, RouterView, useRoute } from 'vue-router'
-import { BeakerIcon, DocumentArrowUpIcon, Squares2X2Icon } from '@heroicons/vue/24/outline'
+import {
+  BeakerIcon,
+  ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
+  DocumentArrowUpIcon,
+  Squares2X2Icon
+} from '@heroicons/vue/24/outline'
 
 const navigationLinks = [
   {
@@ -61,29 +82,81 @@ const navigationLinks = [
 const route = useRoute()
 
 const pageTitle = computed(() => route.meta?.title ?? '')
+
+const sidebarCollapsed = ref(false)
+
+const toggleSidebar = () => {
+  sidebarCollapsed.value = !sidebarCollapsed.value
+}
+
+const sidebarToggleLabel = computed(() =>
+  sidebarCollapsed.value ? '展开侧边栏' : '收起侧边栏'
+)
 </script>
 
 <style scoped>
 .app-shell {
+  --sidebar-width: 280px;
+  --sidebar-collapsed-width: 92px;
   min-height: 100vh;
-  display: grid;
-  grid-template-columns: 280px 1fr;
+  display: flex;
   background: linear-gradient(120deg, #f8fafc 0%, #eef2ff 35%, #f8fafc 100%);
   color: #0f172a;
   font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
 }
 
+.app-shell--collapsed {
+  --sidebar-width: var(--sidebar-collapsed-width);
+}
+
 .app-shell__sidebar {
-  position: sticky;
+  width: var(--sidebar-width);
+  position: fixed;
   top: 0;
-  align-self: stretch;
-  padding: 2.5rem 2rem;
+  left: 0;
+  bottom: 0;
+  height: 100vh;
+  padding: 3.5rem 2rem 2.5rem;
   display: flex;
   flex-direction: column;
   gap: 2rem;
   background: rgba(15, 23, 42, 0.96);
   color: rgba(241, 245, 249, 0.95);
   box-shadow: inset -1px 0 0 rgba(148, 163, 184, 0.18);
+  overflow-y: auto;
+  transition: width 0.3s ease;
+}
+
+.app-shell__sidebar--collapsed {
+  align-items: center;
+  padding: 3.5rem 1.35rem 2.5rem;
+}
+
+.app-shell__collapse-toggle {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  border: none;
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(241, 245, 249, 0.86);
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.app-shell__collapse-toggle:hover {
+  background: rgba(148, 163, 184, 0.28);
+  transform: translateY(-1px);
+}
+
+.app-shell__collapse-icon {
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
 .app-shell__brand {
@@ -91,11 +164,18 @@ const pageTitle = computed(() => route.meta?.title ?? '')
   flex-direction: column;
   gap: 0.25rem;
   color: inherit;
+  transition: opacity 0.25s ease;
+}
+
+.app-shell--collapsed .app-shell__brand {
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .app-shell__logo {
   font-weight: 700;
   font-size: 1.4rem;
+  transition: transform 0.3s ease;
 }
 
 .app-shell__tagline {
@@ -103,6 +183,13 @@ const pageTitle = computed(() => route.meta?.title ?? '')
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(226, 232, 240, 0.7);
+  transition: opacity 0.2s ease;
+}
+
+.app-shell--collapsed .app-shell__tagline {
+  opacity: 0;
+  pointer-events: none;
+  height: 0;
 }
 
 .app-shell__nav {
@@ -122,9 +209,18 @@ const pageTitle = computed(() => route.meta?.title ?? '')
   transition: background 0.2s ease, transform 0.2s ease;
 }
 
+.app-shell--collapsed .app-shell__link {
+  justify-content: center;
+  padding: 0.65rem 0;
+}
+
 .app-shell__link:hover {
   background: rgba(148, 163, 184, 0.12);
   transform: translateX(4px);
+}
+
+.app-shell--collapsed .app-shell__link:hover {
+  transform: translateY(-2px);
 }
 
 .router-link-active.app-shell__link,
@@ -132,6 +228,11 @@ const pageTitle = computed(() => route.meta?.title ?? '')
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(129, 140, 248, 0.35));
   color: #f8fafc;
   box-shadow: 0 18px 45px rgba(15, 23, 42, 0.35);
+}
+
+.app-shell--collapsed .router-link-active.app-shell__link,
+.app-shell--collapsed .router-link-exact-active.app-shell__link {
+  transform: translateY(-2px);
 }
 
 .app-shell__icon {
@@ -143,6 +244,13 @@ const pageTitle = computed(() => route.meta?.title ?? '')
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
+  transition: opacity 0.2s ease;
+}
+
+.app-shell--collapsed .app-shell__link-text {
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
 }
 
 .app-shell__link-label {
@@ -160,9 +268,11 @@ const pageTitle = computed(() => route.meta?.title ?? '')
 }
 
 .app-shell__main {
+  margin-left: var(--sidebar-width);
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  transition: margin-left 0.3s ease;
 }
 
 .app-shell__header {
@@ -196,15 +306,16 @@ const pageTitle = computed(() => route.meta?.title ?? '')
 
 @media (max-width: 960px) {
   .app-shell {
-    grid-template-columns: 1fr;
+    flex-direction: column;
   }
 
   .app-shell__sidebar {
     position: relative;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1.75rem 1.5rem;
+    width: 100%;
+    height: auto;
+    padding: 1.75rem 1.5rem 1.25rem;
+    flex-direction: column;
+    align-items: flex-start;
     gap: 1.5rem;
   }
 
@@ -219,11 +330,8 @@ const pageTitle = computed(() => route.meta?.title ?? '')
     padding: 0.6rem 0.75rem;
   }
 
-  .app-shell__link-text {
-    display: none;
-  }
-
   .app-shell__main {
+    margin-left: 0;
     min-height: auto;
   }
 
@@ -233,6 +341,10 @@ const pageTitle = computed(() => route.meta?.title ?? '')
 
   .app-shell__content {
     padding: 0 1.75rem 2rem;
+  }
+
+  .app-shell__collapse-toggle {
+    display: none;
   }
 }
 

--- a/frontend/src/views/ProjectDataView.vue
+++ b/frontend/src/views/ProjectDataView.vue
@@ -43,9 +43,15 @@
             <span v-else>点击或拖拽文件到此处</span>
           </label>
           <div class="upload-form__actions">
-            <button type="submit" :disabled="!canUpload">
+            <button type="submit" :disabled="uploading">
               {{ uploading ? '上传中…' : '上传并归档' }}
             </button>
+            <p
+              v-if="uploadHelper && !uploadError && !uploadSuccess"
+              class="upload-form__message upload-form__message--hint"
+            >
+              {{ uploadHelper }}
+            </p>
             <p v-if="uploadError" class="upload-form__message upload-form__message--error">{{ uploadError }}</p>
             <p v-if="uploadSuccess" class="upload-form__message upload-form__message--success">{{ uploadSuccess }}</p>
           </div>
@@ -115,9 +121,12 @@ const uploading = ref(false)
 const uploadError = ref('')
 const uploadSuccess = ref('')
 
-const canUpload = computed(
-  () => Boolean(selectedProject.value && uploadFile.value && !uploading.value)
-)
+const uploadHelper = computed(() => {
+  if (uploading.value) return ''
+  if (!selectedProject.value) return '请先在左侧选择一个项目'
+  if (!uploadFile.value) return '请选择需要上传的表格文件'
+  return ''
+})
 
 const fetchProjects = async () => {
   projectLoading.value = true
@@ -173,8 +182,13 @@ const handleFileChange = (event) => {
 }
 
 const uploadDataset = async () => {
-  if (!canUpload.value) {
-    uploadError.value = '请选择项目和文件'
+  if (!selectedProject.value) {
+    uploadError.value = '请选择一个项目'
+    return
+  }
+
+  if (!uploadFile.value) {
+    uploadError.value = '请选择需要上传的文件'
     return
   }
 
@@ -439,6 +453,10 @@ onMounted(fetchProjects)
 
 .upload-form__message--success {
   color: #059669;
+}
+
+.upload-form__message--hint {
+  color: #1d4ed8;
 }
 
 .data-manager__placeholder {


### PR DESCRIPTION
## Summary
- fix the left sidebar so it stays fixed with a collapse/expand toggle animation and adjusted layout spacing
- update the main content area to respect the sidebar state and tidy the navigation presentation when collapsed
- relax the upload button disable logic while surfacing contextual hints if a project or file selection is missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4041d8dc4832783c3d7eea7664a64