### PR TITLE
Fix module path setup for dataset endpoints

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -16,9 +16,12 @@ LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-SRC_DIR = PROJECT_ROOT / "backend" / "src"
-if str(SRC_DIR) not in sys.path:
-    sys.path.insert(0, str(SRC_DIR))
+BACKEND_DIR = PROJECT_ROOT / "backend"
+SRC_DIR = BACKEND_DIR / "src"
+
+for path in (BACKEND_DIR, SRC_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
 
 from src.project import get_project_manager  # type: ignore
 from src.project.storage import (  # type: ignore


### PR DESCRIPTION
## Summary
- ensure the Flask server adds both the backend and src directories to sys.path so project dataset endpoints are available when imported

## Testing
- python - <<'PY'
from backend.server import app
client = app.test_client()
resp = client.get('/api/projects/GLOBAL/datasets')
print(resp.status_code)
print(resp.json)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e4075f5fcc832790aab7bff2b5ca1d