### PR TITLE
feat: share active project selection across dashboard and data views

### DIFF
--- a/frontend/src/composables/useActiveProject.js
+++ b/frontend/src/composables/useActiveProject.js
@@ -1,0 +1,48 @@
+import { computed, ref, watch } from 'vue'
+
+const storageKey = 'opinion-system-active-project'
+const activeProject = ref(null)
+
+if (typeof window !== 'undefined') {
+  const savedName = window.localStorage.getItem(storageKey)
+  if (savedName) {
+    activeProject.value = { name: savedName }
+  }
+}
+
+watch(
+  () => activeProject.value?.name ?? '',
+  (name) => {
+    if (typeof window === 'undefined') return
+    if (name) {
+      window.localStorage.setItem(storageKey, name)
+    } else {
+      window.localStorage.removeItem(storageKey)
+    }
+  }
+)
+
+const setActiveProject = (project) => {
+  if (project && typeof project === 'object') {
+    activeProject.value = { ...project }
+  } else if (typeof project === 'string') {
+    activeProject.value = project ? { name: project } : null
+  } else {
+    activeProject.value = null
+  }
+}
+
+const clearActiveProject = () => {
+  activeProject.value = null
+}
+
+export function useActiveProject() {
+  const activeProjectName = computed(() => activeProject.value?.name ?? '')
+
+  return {
+    activeProject,
+    activeProjectName,
+    setActiveProject,
+    clearActiveProject
+  }
+}


### PR DESCRIPTION
## Summary
- add a composable that stores the active project name and persists it via localStorage
- update the project board to publish selection updates to the shared store
- update the project data manager to consume the shared state and keep datasets in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4c8d152d48327a2346dde2d505c38