### PR TITLE
Add configurable settings management UI and APIs

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -28,6 +28,8 @@ from src.project.storage import (  # type: ignore
     list_project_datasets,
     store_uploaded_dataset,
 )
+from src.utils.setting.editor import load_config as load_settings_config, save_config as save_settings_config  # type: ignore
+from src.utils.setting.settings import settings  # type: ignore
 
 CONFIG_PATH = PROJECT_ROOT / "config.yaml"
 PROJECT_MANAGER = get_project_manager()
@@ -129,6 +131,58 @@ CORS(app)
 
 CONFIG = _load_config()
 
+DATABASES_CONFIG_NAME = "databases"
+LLM_CONFIG_NAME = "llm"
+
+
+def _success(payload: Dict[str, Any], status_code: int = 200):
+    response = {"status": "ok"}
+    response.update(payload)
+    return jsonify(response), status_code
+
+
+def _error(message: str, status_code: int = 400):
+    return jsonify({"status": "error", "message": message}), status_code
+
+
+def _reload_settings() -> None:
+    try:
+        settings.reload()
+    except Exception:
+        LOGGER.warning("Failed to reload runtime settings", exc_info=True)
+
+
+def _load_databases_config() -> Dict[str, Any]:
+    config = load_settings_config(DATABASES_CONFIG_NAME)
+    connections = config.get("connections") or []
+    if not isinstance(connections, list):
+        connections = []
+    config["connections"] = connections
+    return config
+
+
+def _persist_databases_config(config: Dict[str, Any]) -> None:
+    save_settings_config(DATABASES_CONFIG_NAME, config)
+    _reload_settings()
+
+
+def _load_llm_config() -> Dict[str, Any]:
+    config = load_settings_config(LLM_CONFIG_NAME)
+    presets = config.get("presets") or []
+    if not isinstance(presets, list):
+        presets = []
+    config["presets"] = presets
+    filter_llm = config.get("filter_llm") or {}
+    if not isinstance(filter_llm, dict):
+        filter_llm = {}
+    config["filter_llm"] = filter_llm
+    return config
+
+
+def _persist_llm_config(config: Dict[str, Any]) -> None:
+    save_settings_config(LLM_CONFIG_NAME, config)
+    _reload_settings()
+
 
 @app.get("/api/status")
 def status():
@@ -144,6 +198,199 @@ def status():
 @app.get("/api/config")
 def get_config():
     return jsonify(CONFIG)
+
+
+@app.get("/api/settings/databases")
+def list_database_connections():
+    config = _load_databases_config()
+    return _success(
+        {
+            "data": {
+                "connections": config.get("connections", []),
+                "active": config.get("active"),
+            }
+        }
+    )
+
+
+@app.post("/api/settings/databases")
+def create_database_connection():
+    payload = request.get_json(silent=True) or {}
+    required = ["id", "name", "engine", "url"]
+    missing = [field for field in required if not str(payload.get(field, "")).strip()]
+    if missing:
+        return _error(f"Missing required field(s): {', '.join(missing)}")
+
+    connection_id = str(payload["id"]).strip()
+    config = _load_databases_config()
+    connections = config.get("connections", [])
+
+    if any(conn.get("id") == connection_id for conn in connections):
+        return _error(f"Connection '{connection_id}' already exists", status_code=409)
+
+    new_connection = {
+        "id": connection_id,
+        "name": str(payload["name"]).strip(),
+        "engine": str(payload["engine"]).strip(),
+        "url": str(payload["url"]).strip(),
+        "description": str(payload.get("description", "")).strip(),
+    }
+
+    connections.append(new_connection)
+    config["connections"] = connections
+
+    if payload.get("set_active") or not config.get("active"):
+        config["active"] = connection_id
+
+    _persist_databases_config(config)
+
+    return _success({"data": new_connection}, status_code=201)
+
+
+@app.put("/api/settings/databases/<connection_id>")
+def update_database_connection(connection_id: str):
+    payload = request.get_json(silent=True) or {}
+    config = _load_databases_config()
+    connections = config.get("connections", [])
+
+    for connection in connections:
+        if connection.get("id") == connection_id:
+            if "id" in payload and str(payload["id"]).strip() != connection_id:
+                return _error("Connection id cannot be changed")
+
+            for field in ["name", "engine", "url", "description"]:
+                if field in payload:
+                    connection[field] = str(payload[field]).strip()
+
+            if payload.get("set_active"):
+                config["active"] = connection_id
+
+            _persist_databases_config(config)
+            return _success({"data": connection})
+
+    return _error(f"Connection '{connection_id}' was not found", status_code=404)
+
+
+@app.delete("/api/settings/databases/<connection_id>")
+def delete_database_connection(connection_id: str):
+    config = _load_databases_config()
+    connections = config.get("connections", [])
+    remaining = [conn for conn in connections if conn.get("id") != connection_id]
+
+    if len(remaining) == len(connections):
+        return _error(f"Connection '{connection_id}' was not found", status_code=404)
+
+    if config.get("active") == connection_id:
+        return _error("Cannot delete the active database connection", status_code=409)
+
+    config["connections"] = remaining
+    _persist_databases_config(config)
+    return _success({"data": {"deleted": connection_id}})
+
+
+@app.post("/api/settings/databases/<connection_id>/activate")
+def activate_database_connection(connection_id: str):
+    config = _load_databases_config()
+    connections = config.get("connections", [])
+
+    if not any(conn.get("id") == connection_id for conn in connections):
+        return _error(f"Connection '{connection_id}' was not found", status_code=404)
+
+    config["active"] = connection_id
+    _persist_databases_config(config)
+    return _success({"data": {"active": connection_id}})
+
+
+@app.get("/api/settings/llm")
+def get_llm_settings():
+    config = _load_llm_config()
+    return _success({"data": config})
+
+
+@app.put("/api/settings/llm/filter")
+def update_llm_filter():
+    payload = request.get_json(silent=True) or {}
+    config = _load_llm_config()
+    filter_llm = config.get("filter_llm", {})
+
+    for field in ["provider", "model"]:
+        if field in payload:
+            filter_llm[field] = str(payload[field]).strip()
+
+    for field in ["qps", "batch_size", "truncation"]:
+        if field in payload:
+            try:
+                filter_llm[field] = int(payload[field])
+            except (TypeError, ValueError):
+                return _error(f"Field '{field}' must be an integer")
+
+    config["filter_llm"] = filter_llm
+    _persist_llm_config(config)
+    return _success({"data": filter_llm})
+
+
+@app.post("/api/settings/llm/presets")
+def create_llm_preset():
+    payload = request.get_json(silent=True) or {}
+    required = ["id", "name", "provider", "model"]
+    missing = [field for field in required if not str(payload.get(field, "")).strip()]
+    if missing:
+        return _error(f"Missing required field(s): {', '.join(missing)}")
+
+    preset_id = str(payload["id"]).strip()
+    config = _load_llm_config()
+    presets = config.get("presets", [])
+
+    if any(preset.get("id") == preset_id for preset in presets):
+        return _error(f"Preset '{preset_id}' already exists", status_code=409)
+
+    new_preset = {
+        "id": preset_id,
+        "name": str(payload["name"]).strip(),
+        "provider": str(payload["provider"]).strip(),
+        "model": str(payload["model"]).strip(),
+        "description": str(payload.get("description", "")).strip(),
+    }
+
+    presets.append(new_preset)
+    config["presets"] = presets
+    _persist_llm_config(config)
+    return _success({"data": new_preset}, status_code=201)
+
+
+@app.put("/api/settings/llm/presets/<preset_id>")
+def update_llm_preset(preset_id: str):
+    payload = request.get_json(silent=True) or {}
+    config = _load_llm_config()
+    presets = config.get("presets", [])
+
+    for preset in presets:
+        if preset.get("id") == preset_id:
+            if "id" in payload and str(payload["id"]).strip() != preset_id:
+                return _error("Preset id cannot be changed")
+
+            for field in ["name", "provider", "model", "description"]:
+                if field in payload:
+                    preset[field] = str(payload[field]).strip()
+
+            _persist_llm_config(config)
+            return _success({"data": preset})
+
+    return _error(f"Preset '{preset_id}' was not found", status_code=404)
+
+
+@app.delete("/api/settings/llm/presets/<preset_id>")
+def delete_llm_preset(preset_id: str):
+    config = _load_llm_config()
+    presets = config.get("presets", [])
+    remaining = [preset for preset in presets if preset.get("id") != preset_id]
+
+    if len(remaining) == len(presets):
+        return _error(f"Preset '{preset_id}' was not found", status_code=404)
+
+    config["presets"] = remaining
+    _persist_llm_config(config)
+    return _success({"data": {"deleted": preset_id}})
 
 
 @app.post("/api/merge")

--- a/backend/src/utils/setting/editor.py
+++ b/backend/src/utils/setting/editor.py
@@ -1,0 +1,42 @@
+"""Utility helpers for loading and persisting YAML-based project settings."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from .paths import get_configs_root
+
+
+def _ensure_config_dir() -> Path:
+    config_dir = get_configs_root()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+
+def get_config_path(name: str) -> Path:
+    """Return the absolute path for a named configuration file."""
+    config_dir = _ensure_config_dir()
+    filename = f"{name}.yaml" if not name.endswith(".yaml") else name
+    return config_dir / filename
+
+
+def load_config(name: str) -> Dict[str, Any]:
+    """Load a configuration file and return its contents as a dictionary."""
+    path = get_config_path(name)
+    if not path.exists():
+        return {}
+
+    with path.open("r", encoding="utf-8") as stream:
+        data = yaml.safe_load(stream) or {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def save_config(name: str, data: Dict[str, Any]) -> None:
+    """Persist a configuration dictionary to disk as YAML."""
+    path = get_config_path(name)
+    with path.open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(data, stream, allow_unicode=True, sort_keys=False)

--- a/backend/src/utils/setting/settings.py
+++ b/backend/src/utils/setting/settings.py
@@ -3,8 +3,7 @@
 """
 import os
 import yaml
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 from .paths import get_configs_root, get_data_root, get_project_root
 
 
@@ -32,13 +31,17 @@ class Settings:
         config_dir = get_configs_root()
         
         # 加载YAML配置文件
+        self.configs.clear()
+
         yaml_files = list(config_dir.glob("*.yaml"))
         for config_file in yaml_files:
             try:
                 with open(config_file, 'r', encoding='utf-8') as f:
                     self.configs[config_file.stem] = yaml.safe_load(f)
             except Exception as e:
-                pass
+                if logger:
+                    logger.warning("Failed to load config %s: %s", config_file, e)
+                continue
         
         # 加载环境变量配置
         self.configs['env'] = {}
@@ -57,6 +60,10 @@ class Settings:
             'templates_dir': str(project_root / 'templates')
         }
     
+    def reload(self, logger=None) -> None:
+        """Reload configuration files from disk."""
+        self._load_configs(logger)
+
     def get(self, key: str, default: Any = None) -> Any:
         """
         获取配置值，支持点号分隔的嵌套键

--- a/configs/databases.yaml
+++ b/configs/databases.yaml
@@ -1,0 +1,8 @@
+# Database connection definitions for Opinion System
+connections:
+  - id: "local"
+    name: "本地数据库"
+    engine: "sqlite"
+    url: "sqlite:///backend/data/opinion.db"
+    description: "项目默认的本地SQLite数据库"
+active: "local"

--- a/configs/llm.yaml
+++ b/configs/llm.yaml
@@ -1,0 +1,13 @@
+# Large language model configuration for Opinion System
+filter_llm:
+  provider: ""
+  model: ""
+  qps: 10
+  batch_size: 16
+  truncation: 512
+presets:
+  - id: "default"
+    name: "默认预设"
+    provider: ""
+    model: ""
+    description: "默认的LLM配置占位符"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -34,33 +34,38 @@
         <span class="app-shell__brand-mark" aria-hidden="true">OS</span>
         <span class="sr-only">Opinion System 舆情监测系统</span>
       </RouterLink>
-      <nav v-if="!sidebarCollapsed" class="app-shell__nav app-shell__nav--expanded">
-        <RouterLink
-          v-for="link in navigationLinks"
-          :key="link.label"
-          :to="link.to"
-          class="app-shell__link"
-        >
-          <component :is="link.icon" class="app-shell__icon" />
-          <div class="app-shell__link-text">
-            <span class="app-shell__link-label">{{ link.label }}</span>
-            <span class="app-shell__link-description">{{ link.description }}</span>
-          </div>
-        </RouterLink>
-      </nav>
-      <nav v-else class="app-shell__nav app-shell__nav--compact">
-        <RouterLink
-          v-for="link in navigationLinks"
-          :key="link.label"
-          :to="link.to"
-          class="app-shell__link app-shell__link--compact"
-          :title="link.label"
-          :aria-label="link.label"
-        >
-          <component :is="link.icon" class="app-shell__icon app-shell__icon--compact" />
-          <span class="sr-only">{{ link.label }}</span>
-        </RouterLink>
-      </nav>
+      <div
+        class="app-shell__nav-wrapper"
+        :class="sidebarCollapsed ? 'app-shell__nav-wrapper--collapsed' : 'app-shell__nav-wrapper--expanded'"
+      >
+        <nav v-if="!sidebarCollapsed" class="app-shell__nav app-shell__nav--expanded">
+          <RouterLink
+            v-for="link in navigationLinks"
+            :key="link.label"
+            :to="link.to"
+            class="app-shell__link"
+          >
+            <component :is="link.icon" class="app-shell__icon" />
+            <div class="app-shell__link-text">
+              <span class="app-shell__link-label">{{ link.label }}</span>
+              <span class="app-shell__link-description">{{ link.description }}</span>
+            </div>
+          </RouterLink>
+        </nav>
+        <nav v-else class="app-shell__nav app-shell__nav--compact">
+          <RouterLink
+            v-for="link in navigationLinks"
+            :key="link.label"
+            :to="link.to"
+            class="app-shell__link app-shell__link--compact"
+            :title="link.label"
+            :aria-label="link.label"
+          >
+            <component :is="link.icon" class="app-shell__icon app-shell__icon--compact" />
+            <span class="sr-only">{{ link.label }}</span>
+          </RouterLink>
+        </nav>
+      </div>
     </aside>
     <div class="app-shell__main">
       <header class="app-shell__header">
@@ -81,6 +86,7 @@ import {
   BeakerIcon,
   ChevronDoubleLeftIcon,
   ChevronDoubleRightIcon,
+  Cog6ToothIcon,
   DocumentArrowUpIcon,
   Squares2X2Icon
 } from '@heroicons/vue/24/outline'
@@ -103,6 +109,12 @@ const navigationLinks = [
     description: 'API调用测试',
     to: { name: 'test' },
     icon: BeakerIcon
+  },
+  {
+    label: '系统设置',
+    description: '配置数据库与模型参数',
+    to: { name: 'settings' },
+    icon: Cog6ToothIcon
   }
 ]
 
@@ -250,6 +262,17 @@ const sidebarToggleLabel = computed(() =>
   display: flex;
   flex-direction: column;
   width: 100%;
+}
+
+.app-shell__nav-wrapper {
+  margin-top: auto;
+  width: 100%;
+  display: flex;
+  justify-content: stretch;
+}
+
+.app-shell__nav-wrapper--collapsed {
+  justify-content: center;
 }
 
 .app-shell__nav--expanded {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import ProjectBoardView from '../views/ProjectBoardView.vue'
 import ProjectDataView from '../views/ProjectDataView.vue'
 import TestView from '../views/TestView.vue'
+import SettingsView from '../views/SettingsView.vue'
 
 export const routes = [
   {
@@ -27,6 +28,14 @@ export const routes = [
     component: TestView,
     meta: {
       title: '测试界面'
+    }
+  },
+  {
+    path: '/settings',
+    name: 'settings',
+    component: SettingsView,
+    meta: {
+      title: '系统设置'
     }
   },
   {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,0 +1,839 @@
+<template>
+  <div class="settings">
+    <section class="settings__section">
+      <header class="settings__intro">
+        <p class="settings__eyebrow">系统设置</p>
+        <h2>集中管理核心配置</h2>
+        <p>维护数据库连接与模型参数，保持环境配置一致。</p>
+      </header>
+
+      <div class="settings__grid">
+        <article class="settings-card">
+          <header class="settings-card__header">
+            <div>
+              <h3>数据库连接</h3>
+              <p>维护项目可用的数据库连接，并指定默认连接。</p>
+            </div>
+            <button type="button" class="settings-card__action" @click="toggleDatabaseForm">
+              {{ databaseFormVisible ? '关闭表单' : '新增连接' }}
+            </button>
+          </header>
+
+          <p v-if="databaseState.error" class="settings-card__error">{{ databaseState.error }}</p>
+          <p v-if="databaseState.message" class="settings-card__message">{{ databaseState.message }}</p>
+
+          <ul v-if="databaseState.connections.length" class="connection-list">
+            <li
+              v-for="connection in databaseState.connections"
+              :key="connection.id"
+              class="connection-list__item"
+            >
+              <div class="connection-list__meta">
+                <h4>
+                  {{ connection.name }}
+                  <span v-if="databaseState.active === connection.id" class="connection-list__badge">默认</span>
+                </h4>
+                <p class="connection-list__engine">{{ connection.engine }} · {{ connection.url }}</p>
+                <p class="connection-list__description">
+                  {{ connection.description || '暂无描述' }}
+                </p>
+              </div>
+              <div class="connection-list__actions">
+                <button
+                  v-if="databaseState.active !== connection.id"
+                  type="button"
+                  class="settings-button settings-button--ghost"
+                  @click="activateConnection(connection.id)"
+                >
+                  设为默认
+                </button>
+                <button
+                  type="button"
+                  class="settings-button settings-button--ghost"
+                  @click="editDatabaseConnection(connection)"
+                >
+                  编辑
+                </button>
+                <button
+                  type="button"
+                  class="settings-button settings-button--danger"
+                  :disabled="databaseState.active === connection.id"
+                  @click="deleteDatabaseConnection(connection.id)"
+                >
+                  删除
+                </button>
+              </div>
+            </li>
+          </ul>
+          <p v-else-if="!databaseState.loading" class="settings-card__empty">尚未添加数据库连接。</p>
+          <p v-if="databaseState.loading" class="settings-card__loading">加载中…</p>
+
+          <form v-if="databaseFormVisible" class="settings-form" @submit.prevent="submitDatabaseForm">
+            <div class="settings-form__grid">
+              <label class="settings-field">
+                <span>标识</span>
+                <input
+                  v-model.trim="databaseForm.id"
+                  type="text"
+                  :disabled="databaseFormMode === 'edit'"
+                  required
+                  placeholder="如：remote-mysql"
+                />
+              </label>
+              <label class="settings-field">
+                <span>名称</span>
+                <input v-model.trim="databaseForm.name" type="text" required placeholder="展示用名称" />
+              </label>
+              <label class="settings-field">
+                <span>数据库类型</span>
+                <input v-model.trim="databaseForm.engine" type="text" required placeholder="mysql / postgres / sqlite" />
+              </label>
+              <label class="settings-field settings-field--wide">
+                <span>连接 URL</span>
+                <input
+                  v-model.trim="databaseForm.url"
+                  type="text"
+                  required
+                  placeholder="示例：mysql+pymysql://user:pass@host:3306/db"
+                />
+              </label>
+              <label class="settings-field settings-field--wide">
+                <span>描述</span>
+                <textarea
+                  v-model.trim="databaseForm.description"
+                  rows="3"
+                  placeholder="用途说明（可选）"
+                ></textarea>
+              </label>
+              <label class="settings-checkbox">
+                <input v-model="databaseForm.set_active" type="checkbox" />
+                <span>保存后设为默认连接</span>
+              </label>
+            </div>
+            <div class="settings-form__actions">
+              <button type="submit" class="settings-button">
+                {{ databaseFormMode === 'create' ? '新增连接' : '保存修改' }}
+              </button>
+              <button type="button" class="settings-button settings-button--ghost" @click="closeDatabaseForm">
+                取消
+              </button>
+            </div>
+          </form>
+        </article>
+
+        <article class="settings-card">
+          <header class="settings-card__header">
+            <div>
+              <h3>筛选模型配置</h3>
+              <p>配置用于舆情筛选的 LLM 服务和参数。</p>
+            </div>
+          </header>
+
+          <p v-if="llmState.error" class="settings-card__error">{{ llmState.error }}</p>
+          <p v-if="llmState.message" class="settings-card__message">{{ llmState.message }}</p>
+
+          <form class="settings-form" @submit.prevent="submitLlmFilter">
+            <div class="settings-form__grid">
+              <label class="settings-field">
+                <span>服务提供方</span>
+                <input v-model.trim="llmState.filter.provider" type="text" placeholder="如：qwen" />
+              </label>
+              <label class="settings-field">
+                <span>模型名称</span>
+                <input v-model.trim="llmState.filter.model" type="text" placeholder="如：qwen-plus" />
+              </label>
+              <label class="settings-field">
+                <span>QPS</span>
+                <input v-model.number="llmState.filter.qps" type="number" min="0" />
+              </label>
+              <label class="settings-field">
+                <span>批处理大小</span>
+                <input v-model.number="llmState.filter.batch_size" type="number" min="1" />
+              </label>
+              <label class="settings-field">
+                <span>截断长度</span>
+                <input v-model.number="llmState.filter.truncation" type="number" min="0" />
+              </label>
+            </div>
+            <div class="settings-form__actions">
+              <button type="submit" class="settings-button">保存筛选配置</button>
+            </div>
+          </form>
+
+          <section class="preset">
+            <header class="preset__header">
+              <div>
+                <h4>模型预设</h4>
+                <p>维护常用的模型参数组合，方便快速切换。</p>
+              </div>
+              <button type="button" class="settings-card__action" @click="togglePresetForm">
+                {{ llmPresetFormVisible ? '关闭表单' : '新增预设' }}
+              </button>
+            </header>
+
+            <ul v-if="llmState.presets.length" class="preset-list">
+              <li v-for="preset in llmState.presets" :key="preset.id" class="preset-list__item">
+                <div class="preset-list__meta">
+                  <h5>{{ preset.name }}</h5>
+                  <p class="preset-list__engine">{{ preset.provider }} · {{ preset.model }}</p>
+                  <p class="preset-list__description">{{ preset.description || '暂无描述' }}</p>
+                </div>
+                <div class="preset-list__actions">
+                  <button type="button" class="settings-button settings-button--ghost" @click="editPreset(preset)">
+                    编辑
+                  </button>
+                  <button
+                    type="button"
+                    class="settings-button settings-button--danger"
+                    @click="deletePreset(preset.id)"
+                  >
+                    删除
+                  </button>
+                </div>
+              </li>
+            </ul>
+            <p v-else-if="!llmState.loading" class="settings-card__empty">尚未添加模型预设。</p>
+            <p v-if="llmState.loading" class="settings-card__loading">加载中…</p>
+
+            <form v-if="llmPresetFormVisible" class="settings-form" @submit.prevent="submitPresetForm">
+              <div class="settings-form__grid">
+                <label class="settings-field">
+                  <span>标识</span>
+                  <input
+                    v-model.trim="llmPresetForm.id"
+                    type="text"
+                    :disabled="llmPresetFormMode === 'edit'"
+                    required
+                    placeholder="如：default"
+                  />
+                </label>
+                <label class="settings-field">
+                  <span>名称</span>
+                  <input v-model.trim="llmPresetForm.name" type="text" required placeholder="展示用名称" />
+                </label>
+                <label class="settings-field">
+                  <span>服务提供方</span>
+                  <input v-model.trim="llmPresetForm.provider" type="text" required />
+                </label>
+                <label class="settings-field">
+                  <span>模型名称</span>
+                  <input v-model.trim="llmPresetForm.model" type="text" required />
+                </label>
+                <label class="settings-field settings-field--wide">
+                  <span>描述</span>
+                  <textarea v-model.trim="llmPresetForm.description" rows="3" placeholder="用途说明（可选）"></textarea>
+                </label>
+              </div>
+              <div class="settings-form__actions">
+                <button type="submit" class="settings-button">
+                  {{ llmPresetFormMode === 'create' ? '新增预设' : '保存修改' }}
+                </button>
+                <button type="button" class="settings-button settings-button--ghost" @click="closePresetForm">
+                  取消
+                </button>
+              </div>
+            </form>
+          </section>
+        </article>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref } from 'vue'
+
+const databaseState = reactive({
+  connections: [],
+  active: '',
+  loading: false,
+  error: '',
+  message: ''
+})
+
+const databaseFormVisible = ref(false)
+const databaseFormMode = ref('create')
+const databaseForm = reactive({
+  id: '',
+  name: '',
+  engine: 'mysql',
+  url: '',
+  description: '',
+  set_active: true
+})
+
+const llmState = reactive({
+  filter: {
+    provider: '',
+    model: '',
+    qps: 0,
+    batch_size: 1,
+    truncation: 0
+  },
+  presets: [],
+  loading: false,
+  error: '',
+  message: ''
+})
+
+const llmPresetFormVisible = ref(false)
+const llmPresetFormMode = ref('create')
+const llmPresetForm = reactive({
+  id: '',
+  name: '',
+  provider: '',
+  model: '',
+  description: ''
+})
+
+const apiRequest = async (url, options = {}) => {
+  const init = {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    ...options
+  }
+
+  if (init.body && typeof init.body !== 'string') {
+    init.body = JSON.stringify(init.body)
+  }
+
+  const response = await fetch(url, init)
+  const data = await response.json().catch(() => ({}))
+
+  if (!response.ok || data.status === 'error') {
+    const message = data.message || `请求失败（${response.status}）`
+    throw new Error(message)
+  }
+
+  return data
+}
+
+const loadDatabaseConnections = async () => {
+  databaseState.loading = true
+  databaseState.error = ''
+  try {
+    const { data } = await apiRequest('/api/settings/databases')
+    databaseState.connections = data.connections || []
+    databaseState.active = data.active || ''
+  } catch (error) {
+    databaseState.error = error.message
+  } finally {
+    databaseState.loading = false
+  }
+}
+
+const resetDatabaseForm = () => {
+  databaseForm.id = ''
+  databaseForm.name = ''
+  databaseForm.engine = 'mysql'
+  databaseForm.url = ''
+  databaseForm.description = ''
+  databaseForm.set_active = !databaseState.connections.length
+}
+
+const toggleDatabaseForm = () => {
+  if (databaseFormVisible.value) {
+    closeDatabaseForm()
+    return
+  }
+
+  databaseFormMode.value = 'create'
+  resetDatabaseForm()
+  databaseFormVisible.value = true
+}
+
+const editDatabaseConnection = (connection) => {
+  databaseFormMode.value = 'edit'
+  databaseFormVisible.value = true
+  databaseForm.id = connection.id
+  databaseForm.name = connection.name
+  databaseForm.engine = connection.engine
+  databaseForm.url = connection.url
+  databaseForm.description = connection.description || ''
+  databaseForm.set_active = databaseState.active === connection.id
+}
+
+const closeDatabaseForm = () => {
+  databaseFormVisible.value = false
+}
+
+const submitDatabaseForm = async () => {
+  databaseState.error = ''
+  databaseState.message = ''
+
+  const payload = {
+    name: databaseForm.name,
+    engine: databaseForm.engine,
+    url: databaseForm.url,
+    description: databaseForm.description,
+    set_active: databaseForm.set_active
+  }
+
+  const isCreate = databaseFormMode.value === 'create'
+  let endpoint = '/api/settings/databases'
+  let method = 'POST'
+
+  if (isCreate) {
+    payload.id = databaseForm.id
+  } else {
+    endpoint = `/api/settings/databases/${databaseForm.id}`
+    method = 'PUT'
+  }
+
+  try {
+    await apiRequest(endpoint, { method, body: payload })
+    databaseState.message = isCreate ? '新增数据库连接成功' : '数据库连接已更新'
+    databaseFormVisible.value = false
+    await loadDatabaseConnections()
+  } catch (error) {
+    databaseState.error = error.message
+  }
+}
+
+const deleteDatabaseConnection = async (connectionId) => {
+  if (!window.confirm('确定要删除该连接吗？')) {
+    return
+  }
+
+  databaseState.error = ''
+  databaseState.message = ''
+
+  try {
+    await apiRequest(`/api/settings/databases/${connectionId}`, { method: 'DELETE' })
+    databaseState.message = '数据库连接已删除'
+    await loadDatabaseConnections()
+  } catch (error) {
+    databaseState.error = error.message
+  }
+}
+
+const activateConnection = async (connectionId) => {
+  databaseState.error = ''
+  databaseState.message = ''
+
+  try {
+    await apiRequest(`/api/settings/databases/${connectionId}/activate`, { method: 'POST' })
+    databaseState.message = '默认数据库已更新'
+    await loadDatabaseConnections()
+  } catch (error) {
+    databaseState.error = error.message
+  }
+}
+
+const loadLlmConfig = async () => {
+  llmState.loading = true
+  llmState.error = ''
+  try {
+    const { data } = await apiRequest('/api/settings/llm')
+    llmState.filter = {
+      provider: data.filter_llm?.provider || '',
+      model: data.filter_llm?.model || '',
+      qps: data.filter_llm?.qps ?? 0,
+      batch_size: data.filter_llm?.batch_size ?? 1,
+      truncation: data.filter_llm?.truncation ?? 0
+    }
+    llmState.presets = data.presets || []
+  } catch (error) {
+    llmState.error = error.message
+  } finally {
+    llmState.loading = false
+  }
+}
+
+const submitLlmFilter = async () => {
+  llmState.error = ''
+  llmState.message = ''
+
+  try {
+    await apiRequest('/api/settings/llm/filter', {
+      method: 'PUT',
+      body: llmState.filter
+    })
+    llmState.message = '筛选模型配置已保存'
+    await loadLlmConfig()
+  } catch (error) {
+    llmState.error = error.message
+  }
+}
+
+const resetPresetForm = () => {
+  llmPresetForm.id = ''
+  llmPresetForm.name = ''
+  llmPresetForm.provider = ''
+  llmPresetForm.model = ''
+  llmPresetForm.description = ''
+}
+
+const togglePresetForm = () => {
+  if (llmPresetFormVisible.value) {
+    closePresetForm()
+    return
+  }
+
+  llmPresetFormMode.value = 'create'
+  resetPresetForm()
+  llmPresetFormVisible.value = true
+}
+
+const editPreset = (preset) => {
+  llmPresetFormMode.value = 'edit'
+  llmPresetFormVisible.value = true
+  llmPresetForm.id = preset.id
+  llmPresetForm.name = preset.name
+  llmPresetForm.provider = preset.provider
+  llmPresetForm.model = preset.model
+  llmPresetForm.description = preset.description || ''
+}
+
+const closePresetForm = () => {
+  llmPresetFormVisible.value = false
+}
+
+const submitPresetForm = async () => {
+  llmState.error = ''
+  llmState.message = ''
+
+  const payload = {
+    name: llmPresetForm.name,
+    provider: llmPresetForm.provider,
+    model: llmPresetForm.model,
+    description: llmPresetForm.description
+  }
+
+  const isCreate = llmPresetFormMode.value === 'create'
+  let endpoint = '/api/settings/llm/presets'
+  let method = 'POST'
+
+  if (isCreate) {
+    payload.id = llmPresetForm.id
+  } else {
+    endpoint = `/api/settings/llm/presets/${llmPresetForm.id}`
+    method = 'PUT'
+  }
+
+  try {
+    await apiRequest(endpoint, { method, body: payload })
+    llmState.message = isCreate ? '模型预设已新增' : '模型预设已更新'
+    llmPresetFormVisible.value = false
+    await loadLlmConfig()
+  } catch (error) {
+    llmState.error = error.message
+  }
+}
+
+const deletePreset = async (presetId) => {
+  if (!window.confirm('确定要删除该预设吗？')) {
+    return
+  }
+
+  llmState.error = ''
+  llmState.message = ''
+
+  try {
+    await apiRequest(`/api/settings/llm/presets/${presetId}`, { method: 'DELETE' })
+    llmState.message = '模型预设已删除'
+    await loadLlmConfig()
+  } catch (error) {
+    llmState.error = error.message
+  }
+}
+
+onMounted(() => {
+  loadDatabaseConnections()
+  loadLlmConfig()
+})
+</script>
+
+<style scoped>
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.settings__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6366f1;
+  font-weight: 600;
+}
+
+.settings__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.75rem;
+}
+
+.settings-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  backdrop-filter: blur(8px);
+}
+
+.settings-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.settings-card__header h3 {
+  font-size: 1.2rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+.settings-card__header p {
+  margin: 0.35rem 0 0;
+  color: #64748b;
+}
+
+.settings-card__action {
+  border: none;
+  background: #4338ca;
+  color: #f8fafc;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 14px 30px rgba(67, 56, 202, 0.25);
+}
+
+.settings-card__action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(67, 56, 202, 0.28);
+}
+
+.settings-card__error {
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.settings-card__message {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.settings-card__empty,
+.settings-card__loading {
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.connection-list,
+.preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.connection-list__item,
+.preset-list__item {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.connection-list__meta h4,
+.preset-list__meta h5 {
+  margin: 0;
+  font-size: 1.05rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.connection-list__engine,
+.preset-list__engine {
+  font-size: 0.9rem;
+  color: #475569;
+  margin: 0;
+}
+
+.connection-list__description,
+.preset-list__description {
+  font-size: 0.85rem;
+  margin: 0;
+  color: #64748b;
+}
+
+.connection-list__badge {
+  background: rgba(16, 185, 129, 0.16);
+  color: #047857;
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.connection-list__actions,
+.preset-list__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.settings-button {
+  border: none;
+  background: #2563eb;
+  color: #f8fafc;
+  padding: 0.5rem 1.1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.settings-button:hover {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.settings-button--ghost {
+  background: rgba(148, 163, 184, 0.14);
+  color: #0f172a;
+}
+
+.settings-button--ghost:hover {
+  background: rgba(148, 163, 184, 0.22);
+}
+
+.settings-button--danger {
+  background: rgba(248, 113, 113, 0.85);
+}
+
+.settings-button--danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settings-form {
+  border-top: 1px dashed rgba(148, 163, 184, 0.28);
+  padding-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-form__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.settings-field span {
+  color: #334155;
+  font-weight: 600;
+}
+
+.settings-field input,
+.settings-field textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: #0f172a;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-field input:focus,
+.settings-field textarea:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.65);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.settings-field--wide {
+  grid-column: 1 / -1;
+}
+
+.settings-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.settings-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.preset {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preset__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.preset__header h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.preset__header p {
+  margin: 0.35rem 0 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .settings-card {
+    padding: 1.25rem;
+  }
+
+  .settings-form__grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add reusable helpers and Flask endpoints for editing database and LLM settings stored in YAML
- provide baseline configuration files and reload support for the runtime settings loader
- build a new Vue settings view with CRUD forms and pin the sidebar navigation to the bottom

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5197acefc8327ad2b9d35ec926b2c