### PR TITLE
Add database overview page and return structured query data

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,11 @@ def _as_success(result) -> bool:
 
     if isinstance(result, bool):
         return result
+    if isinstance(result, dict):
+        status = result.get("status")
+        if status is not None:
+            return status != "error"
+        return True
     return result is not None
 
 
@@ -66,7 +71,7 @@ def trs_merge(topic, date):
 
     result = run_merge(topic, date)
     _log_project_event(topic, "merge", {"date": date, "source": "cli"}, _as_success(result))
-    if not result:
+    if not _as_success(result):
         print(f"合并失败: {topic} - {date}")
 
 
@@ -81,7 +86,7 @@ def clean(topic, date):
 
     result = run_clean(topic, date)
     _log_project_event(topic, "clean", {"date": date, "source": "cli"}, _as_success(result))
-    if not result:
+    if not _as_success(result):
         print(f"清洗失败: {topic} - {date}")
 
 
@@ -96,7 +101,7 @@ def ai_filter(topic, date):
 
     result = run_filter(topic, date)
     _log_project_event(topic, "filter", {"date": date, "source": "cli"}, _as_success(result))
-    if not result:
+    if not _as_success(result):
         print(f"筛选失败: {topic} - {date}")
 
 
@@ -111,7 +116,7 @@ def upload(topic, date):
 
     result = run_update(topic, date)
     _log_project_event(topic, "upload", {"date": date, "source": "cli"}, _as_success(result))
-    if not result:
+    if not _as_success(result):
         print(f"上传失败: {topic} - {date}")
 
 
@@ -124,7 +129,7 @@ def query():
 
     result = run_query()
     _log_project_event("GLOBAL", "query", {"source": "cli"}, _as_success(result))
-    if not result:
+    if not _as_success(result):
         print("查询失败")
 
 
@@ -145,7 +150,7 @@ def fetch(topic, start, end):
         {"start": start, "end": end, "source": "cli"},
         _as_success(result),
     )
-    if not result:
+    if not _as_success(result):
         print(f"提取失败: {topic} - {start} 到 {end}")
 
 
@@ -167,7 +172,7 @@ def analyze(topic, start, end, func):
         {"start": start, "end": end, "function": func, "source": "cli"},
         _as_success(result),
     )
-    if not result:
+    if not _as_success(result):
         print(f"分析失败: {topic} - {start} 到 {end}")
 
 

--- a/backend/src/query/data_query.py
+++ b/backend/src/query/data_query.py
@@ -1,116 +1,201 @@
 """
 数据查询功能
 """
-import pandas as pd
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
 from ..utils.io.db import DatabaseManager
 from ..utils.setting.settings import settings
-from ..utils.logging.logging import setup_logger, log_module_start, log_success, log_error
+from ..utils.logging.logging import (
+    log_error,
+    log_module_start,
+    log_success,
+    setup_logger,
+)
 
 
-def query_database_info(logger=None) -> bool:
+def _summarise_tables(tables: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """生成表级别统计信息"""
+
+    total_rows = 0
+    counted_tables = 0
+    for table in tables:
+        record_count = table.get("record_count")
+        if isinstance(record_count, (int, float)):
+            total_rows += int(record_count)
+            counted_tables += 1
+
+    return {
+        "table_count": len(tables),
+        "counted_table_count": counted_tables,
+        "total_rows": total_rows,
+    }
+
+
+def query_database_info(logger=None) -> Optional[Dict[str, Any]]:
     """
     查询数据库信息
-    
+
     Args:
         logger: 日志记录器
-    
+
     Returns:
-        bool: 是否成功
+        Optional[Dict[str, Any]]: 查询结果摘要
     """
-    
+
+    db_manager: Optional[DatabaseManager] = None
+
     try:
         # 获取数据库配置
         db_config = settings.get('databases', {})
         db_url = db_config.get('db_url')
-        
+
         if not db_url:
             log_error(logger, "未找到数据库连接配置", "Query")
-            return False
-        
+            return None
+
+        overview: Dict[str, Any] = {
+            "queried_at": datetime.utcnow().isoformat() + "Z",
+            "connection": {},
+            "databases": [],
+            "summary": {},
+        }
+
         # 创建数据库管理器
         db_manager = DatabaseManager(db_url)
-        
+
+        try:
+            from sqlalchemy.engine.url import make_url
+
+            parsed_url = make_url(db_manager.db_url)
+            overview["connection"] = {
+                "driver": parsed_url.drivername,
+                "host": parsed_url.host,
+                "port": parsed_url.port,
+                "database": parsed_url.database,
+                "username": parsed_url.username,
+                "has_password": bool(parsed_url.password),
+            }
+        except Exception:
+            overview["connection"] = {"driver": "unknown"}
+
         # 获取所有数据库（屏蔽系统库）
         databases_query = """
-        SELECT SCHEMA_NAME as database_name 
-        FROM information_schema.SCHEMATA 
+        SELECT SCHEMA_NAME as database_name
+        FROM information_schema.SCHEMATA
         WHERE SCHEMA_NAME NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys', 'test', 'phpmyadmin')
         ORDER BY SCHEMA_NAME
         """
-        
+
         databases_df = db_manager.execute_query(databases_query)
-        
+
         if databases_df.empty:
             log_error(logger, "未找到任何数据库", "Query")
-            return False
-        
-        log_success(logger, f"发现 {len(databases_df)} 个数据库: {', '.join(databases_df['database_name'].tolist())}", "Query")
-        
+            return None
+
+        log_success(
+            logger,
+            f"发现 {len(databases_df)} 个数据库: {', '.join(databases_df['database_name'].tolist())}",
+            "Query",
+        )
+
+        total_tables = 0
+        total_rows = 0
+
         # 遍历每个数据库
         for _, db_row in databases_df.iterrows():
             db_name = db_row['database_name']
-            
+            database_overview: Dict[str, Any] = {
+                "name": db_name,
+                "tables": [],
+            }
+
             # 获取数据库中的表
             tables_query = """
-            SELECT TABLE_NAME as table_name 
-            FROM information_schema.TABLES 
+            SELECT TABLE_NAME as table_name
+            FROM information_schema.TABLES
             WHERE TABLE_SCHEMA = :db_name
             ORDER BY TABLE_NAME
             """
-            
+
             tables_df = db_manager.execute_query(tables_query, {"db_name": db_name})
-            
+
             if tables_df.empty:
                 log_success(logger, f"数据库 {db_name} 无表", "Query")
+                database_overview.update(_summarise_tables([]))
+                overview["databases"].append(database_overview)
                 continue
-            
+
             table_names = tables_df['table_name'].tolist()
-            log_success(logger, f"数据库 {db_name} 包含 {len(table_names)} 个表: {', '.join(table_names)}", "Query")
-            
+            log_success(
+                logger,
+                f"数据库 {db_name} 包含 {len(table_names)} 个表: {', '.join(table_names)}",
+                "Query",
+            )
+
             # 遍历每个表
             for table_name in table_names:
+                table_info: Dict[str, Any] = {"name": table_name}
                 try:
                     # 获取表记录数
                     count_query = f"SELECT COUNT(*) as record_count FROM `{db_name}`.`{table_name}`"
                     count_result = db_manager.execute_query(count_query)
                     record_count = count_result['record_count'].iloc[0]
-                    
+                    table_info["record_count"] = int(record_count)
                     log_success(logger, f"表 {db_name}.{table_name} 包含 {record_count} 条记录", "Query")
-                        
                 except Exception as e:
+                    table_info["error"] = str(e)
                     log_error(logger, f"查询表 {db_name}.{table_name} 信息失败: {e}", "Query")
-                    continue
-        
-        db_manager.close()
-        return True
-        
+                database_overview["tables"].append(table_info)
+
+            stats = _summarise_tables(database_overview["tables"])
+            database_overview.update(stats)
+            total_tables += stats["table_count"]
+            total_rows += stats["total_rows"]
+            overview["databases"].append(database_overview)
+
+        overview["summary"] = {
+            "database_count": len(overview["databases"]),
+            "table_count": total_tables,
+            "row_count": total_rows,
+        }
+
+        log_success(logger, "数据库元信息查询完成", "Query")
+        return overview
+
     except Exception as e:
         log_error(logger, f"查询数据库信息失败: {e}", "Query")
-        return False
+        return None
+    finally:
+        if db_manager is not None:
+            try:
+                db_manager.close()
+            except Exception:
+                pass
 
 
-def run_query(logger=None) -> bool:
+def run_query(logger=None) -> Dict[str, Any]:
     """
     运行数据查询
-    
+
     Args:
         logger: 日志记录器
-    
+
     Returns:
-        bool: 是否成功
+        Dict[str, Any]: 查询结果摘要
     """
     if logger is None:
         logger = setup_logger("Query", "info")
-    
+
     log_module_start(logger, "Query")
 
     try:
         result = query_database_info(logger)
-        if result:
-            return True
-        else:
-            log_error(logger, "模块执行失败", "Query")
-            return False
+        if result is not None:
+            return result
+
+        log_error(logger, "模块执行失败", "Query")
+        return {"status": "error"}
     except Exception as e:
         log_error(logger, f"模块执行失败: {e}", "Query")
-        return False
+        return {"status": "error", "message": str(e)}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -81,6 +81,7 @@ import {
   BeakerIcon,
   ChevronDoubleLeftIcon,
   ChevronDoubleRightIcon,
+  CircleStackIcon,
   DocumentArrowUpIcon,
   Squares2X2Icon
 } from '@heroicons/vue/24/outline'
@@ -97,6 +98,12 @@ const navigationLinks = [
     description: '导入 Excel 并生成数据存档',
     to: { name: 'project-data' },
     icon: DocumentArrowUpIcon
+  },
+  {
+    label: '数据库',
+    description: '查看库表与连接状态',
+    to: { name: 'database' },
+    icon: CircleStackIcon
   },
   {
     label: '测试页面',

--- a/frontend/src/composables/useBackendClient.js
+++ b/frontend/src/composables/useBackendClient.js
@@ -1,0 +1,48 @@
+import { ref } from 'vue'
+
+const API_BASE_FALLBACK = 'http://127.0.0.1:8000'
+
+const backendBase = ref(API_BASE_FALLBACK)
+const configLoaded = ref(false)
+let configPromise = null
+
+const loadConfig = async () => {
+  try {
+    const response = await fetch(`${backendBase.value}/api/config`)
+    if (!response.ok) throw new Error(`配置获取失败: ${response.status}`)
+    const config = await response.json()
+    if (config.backend?.base_url) {
+      backendBase.value = config.backend.base_url
+    } else if (config.backend?.host && config.backend?.port) {
+      backendBase.value = `http://${config.backend.host}:${config.backend.port}`
+    }
+  } catch (error) {
+    console.warn('加载配置失败，使用默认后端地址', error)
+  } finally {
+    configLoaded.value = true
+    configPromise = null
+  }
+}
+
+const ensureConfig = async () => {
+  if (configLoaded.value) return
+  if (!configPromise) {
+    configPromise = loadConfig()
+  }
+  await configPromise
+}
+
+const callApi = async (path, options = {}) => {
+  await ensureConfig()
+  const response = await fetch(`${backendBase.value}${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options
+  })
+  if (!response.ok) {
+    const message = await response.text()
+    throw new Error(message || `请求失败: ${response.status}`)
+  }
+  return response.json()
+}
+
+export const useBackendClient = () => ({ backendBase, ensureConfig, callApi })

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import ProjectBoardView from '../views/ProjectBoardView.vue'
 import ProjectDataView from '../views/ProjectDataView.vue'
+import DatabaseOverviewView from '../views/DatabaseOverviewView.vue'
 import TestView from '../views/TestView.vue'
 
 export const routes = [
@@ -19,6 +20,14 @@ export const routes = [
     component: ProjectDataView,
     meta: {
       title: '项目数据管理'
+    }
+  },
+  {
+    path: '/database',
+    name: 'database',
+    component: DatabaseOverviewView,
+    meta: {
+      title: '数据库查询'
     }
   },
   {

--- a/frontend/src/views/DatabaseOverviewView.vue
+++ b/frontend/src/views/DatabaseOverviewView.vue
@@ -1,0 +1,442 @@
+<template>
+  <section class="database-view">
+    <header class="database-view__header">
+      <CircleStackIcon class="database-view__icon" />
+      <div class="database-view__title-group">
+        <h1>数据库概览</h1>
+        <p>实时查看后端数据库的连接信息、库表结构与数据量，快速验证配置是否正确。</p>
+      </div>
+      <button type="button" class="database-view__refresh" @click="refresh" :disabled="loading">
+        <ArrowPathIcon class="database-view__refresh-icon" :class="{ 'is-spinning': loading }" />
+        {{ loading ? '刷新中…' : '刷新数据' }}
+      </button>
+    </header>
+
+    <section v-if="error" class="database-view__alert" role="alert">
+      <p>{{ error }}</p>
+      <p class="database-view__alert-hint">请检查后端服务与数据库配置，稍后再试。</p>
+    </section>
+
+    <section v-if="hasData" class="database-view__overview">
+      <article class="card">
+        <header>
+          <h2>连接信息</h2>
+          <p>从配置文件推断出的数据库连接要素。</p>
+        </header>
+        <dl class="database-view__details">
+          <div v-for="detail in connectionDetails" :key="detail.label">
+            <dt>{{ detail.label }}</dt>
+            <dd>{{ detail.value }}</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="card">
+        <header>
+          <h2>数据量统计</h2>
+          <p>帮助快速了解业务数据规模。</p>
+        </header>
+        <ul class="database-view__stats">
+          <li>
+            <span class="database-view__stats-label">业务数据库</span>
+            <strong>{{ summaryStats.databaseCount }}</strong>
+          </li>
+          <li>
+            <span class="database-view__stats-label">总表数</span>
+            <strong>{{ summaryStats.tableCount }}</strong>
+          </li>
+          <li>
+            <span class="database-view__stats-label">已统计行数</span>
+            <strong>{{ summaryStats.rowCount }}</strong>
+          </li>
+        </ul>
+        <footer class="database-view__footer" v-if="queriedAt">
+          <ServerStackIcon class="database-view__footer-icon" />
+          <span>最近一次查询：{{ queriedAt }}</span>
+        </footer>
+      </article>
+    </section>
+
+    <section v-if="loading" class="database-view__skeleton">
+      <div class="database-view__skeleton-card" v-for="index in 2" :key="index"></div>
+    </section>
+
+    <section v-if="hasData" class="database-view__databases">
+      <article v-for="database in databases" :key="database.name" class="database-card">
+        <header class="database-card__header">
+          <h3>{{ database.name }}</h3>
+          <p>{{ database.table_count }} 张表 · {{ formatNumber(database.total_rows) }} 行</p>
+        </header>
+        <ul class="database-card__tables">
+          <li
+            v-for="table in database.tables"
+            :key="table.name"
+            :class="['database-card__table', { 'database-card__table--error': table.error }]"
+          >
+            <span class="database-card__table-name">{{ table.name }}</span>
+            <span v-if="table.error" class="database-card__table-error">{{ table.error }}</span>
+            <span v-else class="database-card__table-count">{{ formatNumber(table.record_count) }} 行</span>
+          </li>
+        </ul>
+        <p v-if="!database.tables.length" class="database-card__empty">该库暂无业务表。</p>
+      </article>
+    </section>
+
+    <p v-if="!loading && !hasData && !error" class="database-view__empty">
+      未检索到业务数据库，请确认配置是否正确。
+    </p>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { ArrowPathIcon, CircleStackIcon, ServerStackIcon } from '@heroicons/vue/24/outline'
+
+import { useBackendClient } from '../composables/useBackendClient'
+
+const { callApi } = useBackendClient()
+
+const loading = ref(false)
+const error = ref('')
+const payload = ref(null)
+
+const numberFormatter = new Intl.NumberFormat('zh-CN')
+const formatNumber = (value) => {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return '—'
+  return numberFormatter.format(Number(value))
+}
+
+const queriedAt = computed(() => {
+  if (!payload.value?.queried_at) return ''
+  try {
+    return new Date(payload.value.queried_at).toLocaleString()
+  } catch (err) {
+    return payload.value.queried_at
+  }
+})
+
+const connectionDetails = computed(() => {
+  const connection = payload.value?.connection ?? {}
+  const items = [
+    { label: '驱动', value: connection.driver || '未知' },
+    { label: '主机', value: connection.host || '未配置' },
+    { label: '端口', value: connection.port || '未配置' },
+    { label: '默认数据库', value: connection.database || '未配置' },
+    { label: '用户名', value: connection.username || '未配置' },
+    {
+      label: '密码配置',
+      value: connection.has_password ? '已配置' : '未配置'
+    }
+  ]
+  return items.filter((item) => item.value !== undefined && item.value !== null)
+})
+
+const summaryStats = computed(() => {
+  const summary = payload.value?.summary ?? {}
+  return {
+    databaseCount: summary.database_count ? formatNumber(summary.database_count) : '0',
+    tableCount: summary.table_count ? formatNumber(summary.table_count) : '0',
+    rowCount: summary.row_count ? formatNumber(summary.row_count) : '0'
+  }
+})
+
+const databases = computed(() => payload.value?.databases ?? [])
+const hasData = computed(() => (databases.value?.length ?? 0) > 0)
+
+const refresh = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const response = await callApi('/api/query', { method: 'POST', body: JSON.stringify({}) })
+    payload.value = response.data ?? null
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+    payload.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(refresh)
+</script>
+
+<style scoped>
+.database-view {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 25px 60px -30px rgba(15, 23, 42, 0.35);
+}
+
+.database-view__header {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.database-view__icon {
+  width: 3rem;
+  height: 3rem;
+  color: #0f172a;
+}
+
+.database-view__title-group h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.database-view__title-group p {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  max-width: 640px;
+}
+
+.database-view__refresh {
+  margin-left: auto;
+  border: none;
+  background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
+  color: #fff;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.database-view__refresh:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.database-view__refresh:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.28);
+}
+
+.database-view__refresh-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.database-view__refresh-icon.is-spinning {
+  animation: spin 1s linear infinite;
+}
+
+.database-view__alert {
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  color: #b91c1c;
+}
+
+.database-view__alert p {
+  margin: 0.25rem 0;
+}
+
+.database-view__alert-hint {
+  color: rgba(185, 28, 28, 0.8);
+}
+
+.database-view__overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+}
+
+.database-view__details {
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.database-view__details div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  padding-bottom: 0.6rem;
+}
+
+.database-view__details dt {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.database-view__details dd {
+  margin: 0;
+  color: #475569;
+}
+
+.database-view__stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.database-view__stats-label {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.database-view__stats strong {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.database-view__footer {
+  margin-top: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #475569;
+}
+
+.database-view__footer-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.database-view__skeleton {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.database-view__skeleton-card {
+  height: 140px;
+  border-radius: 22px;
+  background: linear-gradient(90deg, rgba(226, 232, 240, 0.6), rgba(241, 245, 249, 0.9), rgba(226, 232, 240, 0.6));
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.database-view__databases {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.75rem;
+}
+
+.database-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 1.5rem 1.75rem;
+  box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.database-card__header h3 {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.database-card__header p {
+  margin: 0.35rem 0 0;
+  color: #475569;
+}
+
+.database-card__tables {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.database-card__table {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 14px;
+  align-items: baseline;
+}
+
+.database-card__table-name {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.database-card__table-count {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.database-card__table--error {
+  border: 1px solid rgba(220, 38, 38, 0.25);
+  background: rgba(220, 38, 38, 0.05);
+}
+
+.database-card__table-error {
+  color: #b91c1c;
+  font-weight: 600;
+  text-align: right;
+}
+
+.database-card__empty {
+  margin: 0;
+  color: #64748b;
+  font-style: italic;
+}
+
+.database-view__empty {
+  margin: 0;
+  text-align: center;
+  color: #64748b;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .database-view {
+    padding: 1.75rem;
+    border-radius: 22px;
+  }
+
+  .database-view__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .database-view__refresh {
+    margin-left: 0;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- return detailed database metadata from the query module and align CLI success handling
- add a shared backend client composable and a dedicated database overview view with navigation
- replace the inline query tester in the API workbench with a link to the new page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e51b353ef483279e15a426d0e75ef0