### PR TITLE
Fix project menu overflow in project board

### DIFF
--- a/frontend/src/views/ProjectBoardView.vue
+++ b/frontend/src/views/ProjectBoardView.vue
@@ -1171,6 +1171,9 @@ watch(activeProjectName, (name) => {
   list-style: none;
   margin: 0;
   z-index: 10;
+  max-height: 14rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .project-tile__menu li {


### PR DESCRIPTION
## Summary
- limit the project tile action menu height and enable scrolling for overflow items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52251033c83279022a8638b25c70a