### PR TITLE
Fix modal overflow to allow scrolling

### DIFF
--- a/frontend/src/views/ProjectBoardView.vue
+++ b/frontend/src/views/ProjectBoardView.vue
@@ -1283,6 +1283,7 @@ watch(activeProjectName, (name) => {
   align-items: center;
   justify-content: center;
   padding: 2rem;
+  overflow-y: auto;
   z-index: 50;
 }
 
@@ -1296,6 +1297,8 @@ watch(activeProjectName, (name) => {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
 }
 
 .modal__panel--wide {
@@ -1408,10 +1411,12 @@ watch(activeProjectName, (name) => {
 
   .modal__panel {
     padding: 1.5rem;
+    max-height: calc(100vh - 3rem);
   }
 
   .modal__panel--wide {
     padding: 1.5rem;
+    max-height: calc(100vh - 3rem);
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- allow modal overlay to scroll when content exceeds the viewport
- constrain modal panel height and enable internal scrolling to prevent clipped content
- adjust responsive modal height limits for smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e523d94e5c8327a5874d907bd06e8d