### PR TITLE
Fix settings API requests when backend proxy missing

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -346,9 +346,21 @@ const apiRequest = async (url, options = {}) => {
   }
 
   const response = await fetch(resolveApiUrl(url), init)
-  const data = await response.json().catch(() => {
-    throw new Error('无法解析服务器返回的数据')
-  })
+  const rawText = await response.text()
+  let data
+
+  if (!rawText.trim()) {
+    data = {}
+  } else {
+    try {
+      data = JSON.parse(rawText)
+    } catch (error) {
+      const statusLabel = `${response.status} ${response.statusText || ''}`.trim()
+      const preview = rawText.slice(0, 120).replace(/\s+/g, ' ')
+      const detail = preview ? `：${preview}` : ''
+      throw new Error(`无法解析服务器返回的数据（${statusLabel || '未知状态'}）${detail}`)
+    }
+  }
 
   if (!response.ok || data.status === 'error') {
     const message = data.message || `请求失败（${response.status}）`

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,17 @@ export default defineConfig({
   plugins: [vue()],
   server: {
     host: '0.0.0.0',
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: process.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000',
+        changeOrigin: true,
+        configure: (proxy) => {
+          proxy.on('error', (err, req, res) => {
+            console.error('API proxy error:', err?.message || err)
+          })
+        }
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- configure the Vite dev server to proxy /api requests to the backend with a configurable target and basic error logging
- make the settings view API helper gracefully handle empty and non-JSON responses with clearer error messages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e526b7e78c8327bd697c29b79dca8c